### PR TITLE
Use tokenizer for max_new_tokens and mock in tests

### DIFF
--- a/rag_qa_chatbot.py
+++ b/rag_qa_chatbot.py
@@ -155,13 +155,17 @@ class QAChatbot:
         
         if self.generator is None:
             return self._simple_answer(relevant_context, question)
-        
+
         try:
             prompt = self._build_prompt(relevant_context, question)
-            
+            encoded = self.tokenizer(prompt, return_tensors="pt")
+            prompt_tokens = encoded.input_ids.shape[1]
+            max_tokens = 512
+            max_new_tokens = max(1, max_tokens - prompt_tokens)
+
             response = self.generator(
                 prompt,
-                max_length=len(prompt.split()) + 100,
+                max_new_tokens=max_new_tokens,
                 num_return_sequences=1,
                 temperature=0.7
             )


### PR DESCRIPTION
## Summary
- adjust QAChatbot answer to compute prompt token length and derive max_new_tokens
- update quick and integration tests to mock tokenizer and generator

## Testing
- `python quick_test.py`
- `python test_rag_chatbot.py`


------
https://chatgpt.com/codex/tasks/task_e_688dbf83df88832aaf64585b29693553