### PR TITLE
feat: add customizable company name

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ kb_manager = KnowledgeBaseManager()
 kb_manager.build_index(documents)
 
 # 3. チャットボット初期化
-chatbot = QAChatbot(kb_manager)
+chatbot = QAChatbot(kb_manager, company_name="株式会社AIシステム")
 
 # 4. 質問と回答
 answer = chatbot.answer("経費精算の上限はいくらですか？")
@@ -154,7 +154,8 @@ chatbot = QAChatbotAzure(
     knowledge_base=kb_manager,
     azure_endpoint='your-endpoint',
     api_key='your-key',
-    deployment_name='gpt-35-turbo'
+    deployment_name='gpt-35-turbo',
+    company_name='株式会社AIシステム'
 )
 
 # 質問と回答
@@ -243,7 +244,7 @@ kb_manager = KnowledgeBaseManager(
 # 接続テスト実行
 python -c "
 from rag_qa_chatbot_azure import QAChatbotAzure
-chatbot = QAChatbotAzure(None)
+chatbot = QAChatbotAzure(None, company_name='株式会社AIシステム')
 chatbot.test_connection()
 "
 ```

--- a/azure_demo.py
+++ b/azure_demo.py
@@ -25,10 +25,10 @@ def run_azure_demo_with_mock():
     print("📚 ナレッジベースを構築中...")
     kb_manager = KnowledgeBaseManager()
     kb_manager.build_index(documents)
-    
+
     # Azure チャットボット初期化（設定なしでフォールバック）
     print("\n🤖 Azure チャットボットを初期化中...")
-    chatbot = QAChatbotAzure(knowledge_base=kb_manager)
+    chatbot = QAChatbotAzure(knowledge_base=kb_manager, company_name="株式会社デモ")
     
     # デモ質問
     questions = [
@@ -70,7 +70,8 @@ def show_azure_setup_example():
     print("    azure_endpoint='https://your-openai-resource.openai.azure.com/',")
     print("    api_key='your-api-key',")
     print("    deployment_name='gpt-35-turbo',  # または 'gpt-4'")
-    print("    api_version='2024-02-15-preview'")
+    print("    api_version='2024-02-15-preview',")
+    print("    company_name='your-company'")
     print(")")
     print()
     print("# 質問と回答")

--- a/demo_light.py
+++ b/demo_light.py
@@ -95,8 +95,8 @@ def run_demo():
         with patch('rag_qa_chatbot.AutoTokenizer'), \
              patch('rag_qa_chatbot.AutoModelForCausalLM'), \
              patch('rag_qa_chatbot.pipeline'):
-            
-            chatbot = QAChatbot(kb_manager)
+
+            chatbot = QAChatbot(kb_manager, company_name="株式会社デモ")
             chatbot.generator = None  # シンプル回答を使用
             
             print("\n✨ デモンストレーション開始\n")

--- a/rag_qa_chatbot.py
+++ b/rag_qa_chatbot.py
@@ -71,20 +71,21 @@ class KnowledgeBaseManager:
         faiss.normalize_L2(query_embedding)
         
         scores, indices = self.index.search(query_embedding, top_k)
-        
+
         relevant_chunks = []
-        for idx in indices[0]:
+        for idx in indices[0][:top_k]:
             if idx < len(self.chunks):
                 relevant_chunks.append(self.chunks[idx])
-        
+
         return relevant_chunks
 
 
 class QAChatbot:
     """ユーザーとの対話と回答生成のメインロジックを担うクラス"""
-    
-    def __init__(self, knowledge_base: KnowledgeBaseManager):
+
+    def __init__(self, knowledge_base: KnowledgeBaseManager, company_name: str = "株式会社○○"):
         self.knowledge_base = knowledge_base
+        self.company_name = company_name
         print("言語モデルを初期化中...")
         
         model_name = "microsoft/DialoGPT-medium"
@@ -113,8 +114,8 @@ class QAChatbot:
     def _build_prompt(self, context: List[str], question: str) -> str:
         """プロンプトを構築"""
         context_text = "\n".join(context) if context else "関連する情報が見つかりませんでした。"
-        
-        prompt = f"""あなたは、株式会社○○の社内情報を的確に教える、親切なAIアシスタントです。
+
+        prompt = f"""あなたは、{self.company_name}の社内情報を的確に教える、親切なAIアシスタントです。
 
 以下の社内情報を参考にして、質問に答えてください。
 ---
@@ -238,8 +239,8 @@ if __name__ == "__main__":
     try:
         kb_manager = KnowledgeBaseManager()
         kb_manager.build_index(dummy_documents)
-        
-        chatbot = QAChatbot(kb_manager)
+
+        chatbot = QAChatbot(kb_manager, company_name="株式会社デモ")
         
         test_questions = [
             "経費精算の上限はいくらですか？",

--- a/rag_qa_chatbot_azure.py
+++ b/rag_qa_chatbot_azure.py
@@ -71,27 +71,29 @@ class KnowledgeBaseManager:
         faiss.normalize_L2(query_embedding)
         
         scores, indices = self.index.search(query_embedding, top_k)
-        
+
         relevant_chunks = []
-        for idx in indices[0]:
+        for idx in indices[0][:top_k]:
             if idx < len(self.chunks):
                 relevant_chunks.append(self.chunks[idx])
-        
+
         return relevant_chunks
 
 
 class QAChatbotAzure:
     """Azure OpenAIを使用したQAチャットボット"""
     
-    def __init__(self, 
+    def __init__(self,
                  knowledge_base: KnowledgeBaseManager,
                  azure_endpoint: Optional[str] = None,
                  api_key: Optional[str] = None,
                  api_version: str = "2024-02-15-preview",
-                 deployment_name: str = "gpt-35-turbo"):
-        
+                 deployment_name: str = "gpt-35-turbo",
+                 company_name: str = "株式会社○○"):
+
         self.knowledge_base = knowledge_base
         self.deployment_name = deployment_name
+        self.company_name = company_name
         
         # Azure OpenAI設定
         self.azure_endpoint = azure_endpoint or os.getenv("AZURE_OPENAI_ENDPOINT")
@@ -121,8 +123,8 @@ class QAChatbotAzure:
     def _build_prompt(self, context: List[str], question: str) -> str:
         """プロンプトを構築"""
         context_text = "\n".join(context) if context else "関連する情報が見つかりませんでした。"
-        
-        prompt = f"""あなたは、株式会社○○の社内情報を的確に教える、親切なAIアシスタントです。
+
+        prompt = f"""あなたは、{self.company_name}の社内情報を的確に教える、親切なAIアシスタントです。
 
 以下の社内情報を参考にして、質問に答えてください。
 ---
@@ -224,7 +226,8 @@ def setup_azure_config():
     print("       knowledge_base=kb_manager,")
     print("       azure_endpoint='https://your-resource.openai.azure.com/',")
     print("       api_key='your-api-key',")
-    print("       deployment_name='your-deployment-name'")
+    print("       deployment_name='your-deployment-name',")
+    print("       company_name='your-company'")
     print("   )")
     
     print("\n📝 必要な情報:")
@@ -313,7 +316,8 @@ if __name__ == "__main__":
             knowledge_base=kb_manager,
             # azure_endpoint="https://your-resource.openai.azure.com/",
             # api_key="your-api-key",
-            deployment_name="gpt-35-turbo"  # または "gpt-4"
+            deployment_name="gpt-35-turbo",  # または "gpt-4"
+            company_name="株式会社デモ"
         )
         
         # 接続テスト

--- a/test_rag_chatbot.py
+++ b/test_rag_chatbot.py
@@ -97,10 +97,12 @@ class TestQAChatbot(unittest.TestCase):
         """プロンプト構築のテスト"""
         context = ["経費精算の上限は50,000円です。", "申請は月末までに行ってください。"]
         question = "経費精算の上限はいくらですか？"
-        
+
+        # 会社名をカスタマイズしてプロンプトに反映されることを確認
+        self.chatbot.company_name = "株式会社テスト"
         prompt = self.chatbot._build_prompt(context, question)
-        
-        self.assertIn("株式会社○○", prompt)
+
+        self.assertIn("株式会社テスト", prompt)
         self.assertIn(question, prompt)
         self.assertIn(context[0], prompt)
         self.assertIn(context[1], prompt)


### PR DESCRIPTION
## Summary
- allow setting a company name in `QAChatbot` and `QAChatbotAzure` constructors and use it in prompt creation
- ensure search results respect the requested `top_k`
- update docs, examples, and tests for the new parameter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dc17afafc832a80876ebb1828cc25