### PR TITLE
Add English README and multi-cloud support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # RAG型社内QAチャットボット
 
+👉 [English README available](README_en.md)
+
 RAG (Retrieval-Augmented Generation) アーキテクチャを使用した社内ドキュメント検索・回答システムです。社内の文書を知識ベースとして、従業員からの質問に自動で回答します。
 
 ## 🌟 特徴
 
 - **RAGアーキテクチャ**: 検索と生成を組み合わせた高精度な回答システム
-- **多様なLLM対応**: Hugging Face Transformers、Azure OpenAI API対応
+- **多様なLLM対応**: Hugging Face Transformers、Azure OpenAI API、AWS Bedrock に対応
 - **高速検索**: FAISS による効率的なベクトル検索
 - **日本語対応**: 日本語の社内文書に最適化
 - **簡単セットアップ**: 軽量で導入しやすい設計
@@ -30,6 +32,7 @@ graph LR
 
 ```
 ├── README.md                    # このファイル
+├── README_en.md                 # 英語版README
 ├── .gitignore                   # Git除外設定
 ├── requirements.txt             # 基本版依存関係
 ├── requirements_azure.txt       # Azure版依存関係
@@ -86,6 +89,21 @@ export AZURE_OPENAI_API_KEY='your-api-key'
 python rag_qa_chatbot_azure.py
 ```
 
+### 4. AWS Bedrock版実行
+
+```bash
+# boto3インストール（未インストールの場合）
+pip install boto3
+
+# 必要な環境変数を設定（AWS CLI設定済みなら不要）
+export AWS_ACCESS_KEY_ID='your-access-key'
+export AWS_SECRET_ACCESS_KEY='your-secret-key'
+export AWS_REGION='us-east-1'
+
+# AWS版実行
+python rag_qa_chatbot.py --provider aws --model_id amazon.titan-text-lite-v1
+```
+
 ## ⚙️ 設定方法
 
 ### 基本版設定
@@ -112,6 +130,24 @@ chatbot = QAChatbotAzure(
     azure_endpoint='https://your-resource.openai.azure.com/',
     api_key='your-api-key',
     deployment_name='gpt-35-turbo'
+)
+```
+
+### AWS Bedrock版設定
+
+AWS CLIで認証情報を設定済みであれば追加設定は不要です。プログラム内で明示的に指定する場合：
+
+```python
+from rag_qa_chatbot import KnowledgeBaseManager, QAChatbot
+
+kb_manager = KnowledgeBaseManager()
+kb_manager.build_index(documents)
+
+chatbot = QAChatbot(
+    kb_manager,
+    provider="aws",
+    region_name="us-east-1",
+    model_id="amazon.titan-text-lite-v1"
 )
 ```
 

--- a/README_en.md
+++ b/README_en.md
@@ -1,0 +1,150 @@
+# RAG-Style Internal QA Chatbot
+
+This project provides a document retrieval and question answering system based on the Retrieval-Augmented Generation (RAG) architecture. Company documents are indexed as a knowledge base so that employees can ask questions and receive automatic answers.
+
+## 🌟 Features
+
+- **RAG Architecture**: Combines retrieval and generation for accurate answers
+- **Multiple LLM Providers**: Works with Hugging Face Transformers, Azure OpenAI, and AWS Bedrock
+- **Fast Search**: Efficient vector search powered by FAISS
+- **Japanese Support**: Optimised for Japanese internal documents
+- **Easy Setup**: Lightweight design for quick adoption
+
+## 🏗️ System Architecture
+
+```mermaid
+graph LR
+    A[Internal Documents] --> B[KnowledgeBaseManager]
+    B --> C[Chunk Split]
+    C --> D[Embedding]
+    D --> E[FAISS Index]
+    F[User Question] --> G[QAChatbot]
+    G --> H[Retrieve Context]
+    E --> H
+    H --> I[Prompt Builder]
+    I --> J[LLM Generation]
+    J --> K[Answer]
+```
+
+## 📂 Project Structure
+
+```
+├── README.md              # Japanese README
+├── README_en.md           # This file
+├── .gitignore             # Git ignore settings
+├── requirements.txt       # Basic dependencies
+├── requirements_azure.txt # Azure specific deps
+├── .env.template          # Environment variable template
+├── rag_qa_chatbot.py      # Main implementation (multi-provider)
+├── rag_qa_chatbot_azure.py# Legacy Azure implementation
+├── test_rag_chatbot.py    # Comprehensive tests
+├── quick_test.py          # Lightweight tests
+├── demo_light.py          # Lightweight demo
+└── azure_demo.py          # Azure demo script
+```
+
+## 🚀 Quick Start
+
+### 1. Environment Setup
+
+```bash
+# Clone repository
+git clone <repository-url>
+cd qa-bot-azure
+
+# Create virtual environment (recommended)
+python -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+
+# Install dependencies
+pip install -r requirements.txt
+```
+
+### 2. Local Execution
+
+```bash
+# Run lightweight tests
+python quick_test.py
+
+# Run lightweight demo
+python demo_light.py
+
+# Full demo (downloads models)
+python rag_qa_chatbot.py
+```
+
+### 3. Azure OpenAI Execution
+
+```bash
+pip install -r requirements_azure.txt
+
+export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
+export AZURE_OPENAI_API_KEY="your-api-key"
+
+python rag_qa_chatbot.py --provider azure --deployment_name gpt-35-turbo
+```
+
+### 4. AWS Bedrock Execution
+
+```bash
+pip install boto3
+
+# Set credentials if not already configured via AWS CLI
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+export AWS_REGION="us-east-1"
+
+python rag_qa_chatbot.py --provider aws --model_id amazon.titan-text-lite-v1
+```
+
+## ⚙️ Configuration
+
+### Basic Version
+Uses Hugging Face Transformers and requires no special settings.
+
+### Azure OpenAI
+Use environment variables (`AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_DEPLOYMENT`) or pass parameters to `QAChatbot`.
+
+### AWS Bedrock
+Credentials can be supplied via the AWS CLI or passed directly to `QAChatbot` using `region_name` and `model_id`.
+
+## 🔧 Usage
+
+```python
+from rag_qa_chatbot import KnowledgeBaseManager, QAChatbot
+
+kb_manager = KnowledgeBaseManager()
+kb_manager.build_index(documents)
+
+chatbot = QAChatbot(kb_manager, provider="aws")
+answer = chatbot.answer("Tell me about paid leave")
+print(answer)
+```
+
+## 🧪 Tests
+
+```bash
+python quick_test.py
+python test_rag_chatbot.py
+```
+
+## 📊 System Requirements
+
+- Python 3.8+
+- Memory: 4GB+ recommended
+
+## 🎛️ Customisation
+
+- Adjust chunk size via `kb_manager.chunk_size`
+- Change number of retrieved passages with `kb_manager.search(question, top_k=5)`
+- Use different embedding models through `KnowledgeBaseManager(embedding_model_name="sentence-transformers/all-MiniLM-L6-v2")`
+
+## 🔍 Troubleshooting
+
+- **Memory errors**: Try a smaller embedding model like `intfloat/multilingual-e5-small`
+- **Azure errors**: Run connection test via `QAChatbot(..., provider="azure").client`
+- **Encoding issues**: Open files with `encoding='utf-8'`
+
+---
+
+This project aims to provide a simple yet extensible foundation for internal Q&A chatbots that work both locally and across major cloud providers.

--- a/rag_qa_chatbot.py
+++ b/rag_qa_chatbot.py
@@ -4,7 +4,19 @@ from sentence_transformers import SentenceTransformer
 from transformers import pipeline, AutoTokenizer, AutoModelForCausalLM
 import torch
 import re
-from typing import List, Tuple
+import os
+import json
+from typing import List, Tuple, Optional
+
+try:
+    from openai import AzureOpenAI
+except Exception:
+    AzureOpenAI = None
+
+try:
+    import boto3
+except Exception:
+    boto3 = None
 
 
 class KnowledgeBaseManager:
@@ -86,33 +98,76 @@ class KnowledgeBaseManager:
 
 class QAChatbot:
     """ユーザーとの対話と回答生成のメインロジックを担うクラス"""
-    
-    def __init__(self, knowledge_base: KnowledgeBaseManager):
+
+    def __init__(self,
+                 knowledge_base: KnowledgeBaseManager,
+                 provider: str = "local",
+                 **kwargs):
         self.knowledge_base = knowledge_base
-        print("言語モデルを初期化中...")
-        
-        model_name = "microsoft/DialoGPT-medium"
-        try:
-            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-            self.model = AutoModelForCausalLM.from_pretrained(model_name)
-            
-            if self.tokenizer.pad_token is None:
-                self.tokenizer.pad_token = self.tokenizer.eos_token
-            
-            self.generator = pipeline(
-                "text-generation",
-                model=self.model,
-                tokenizer=self.tokenizer,
-                max_length=512,
-                num_return_sequences=1,
-                temperature=0.7,
-                do_sample=True,
-                pad_token_id=self.tokenizer.eos_token_id
-            )
-        except Exception as e:
-            print(f"LLMの初期化に失敗しました: {e}")
-            print("シンプルなテンプレートベースの回答システムを使用します。")
-            self.generator = None
+        self.provider = provider
+        self.generator = None
+        self.client = None
+
+        if provider == "local":
+            print("言語モデルを初期化中...")
+            model_name = "microsoft/DialoGPT-medium"
+            try:
+                self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+                self.model = AutoModelForCausalLM.from_pretrained(model_name)
+
+                if self.tokenizer.pad_token is None:
+                    self.tokenizer.pad_token = self.tokenizer.eos_token
+
+                self.generator = pipeline(
+                    "text-generation",
+                    model=self.model,
+                    tokenizer=self.tokenizer,
+                    max_length=512,
+                    num_return_sequences=1,
+                    temperature=0.7,
+                    do_sample=True,
+                    pad_token_id=self.tokenizer.eos_token_id
+                )
+            except Exception as e:
+                print(f"LLMの初期化に失敗しました: {e}")
+                print("シンプルなテンプレートベースの回答システムを使用します。")
+                self.generator = None
+
+        elif provider == "azure":
+            if AzureOpenAI is None:
+                print("openaiライブラリが見つかりません。シンプルなテンプレートベースの回答システムを使用します。")
+            else:
+                azure_endpoint = kwargs.get("azure_endpoint") or os.getenv("AZURE_OPENAI_ENDPOINT")
+                api_key = kwargs.get("api_key") or os.getenv("AZURE_OPENAI_API_KEY")
+                self.deployment_name = kwargs.get("deployment_name", "gpt-35-turbo")
+                api_version = kwargs.get("api_version", "2024-02-15-preview")
+
+                if not azure_endpoint or not api_key:
+                    print("⚠️ Azure OpenAI の設定が見つかりません。シンプルなテンプレートベースの回答システムを使用します。")
+                else:
+                    try:
+                        print("Azure OpenAI クライアントを初期化中...")
+                        self.client = AzureOpenAI(
+                            azure_endpoint=azure_endpoint,
+                            api_key=api_key,
+                            api_version=api_version
+                        )
+                        print("✅ Azure OpenAI 接続成功")
+                    except Exception as e:
+                        print(f"❌ Azure OpenAI の初期化に失敗しました: {e}")
+
+        elif provider == "aws":
+            if boto3 is None:
+                print("boto3 がインストールされていません。シンプルなテンプレートベースの回答システムを使用します。")
+            else:
+                region_name = kwargs.get("region_name") or os.getenv("AWS_REGION") or "us-east-1"
+                self.model_id = kwargs.get("model_id", "amazon.titan-text-lite-v1")
+                try:
+                    print("AWS Bedrock クライアントを初期化中...")
+                    self.client = boto3.client("bedrock-runtime", region_name=region_name)
+                    print("✅ AWS Bedrock 接続成功")
+                except Exception as e:
+                    print(f"❌ AWS Bedrock の初期化に失敗しました: {e}")
     
     def _build_prompt(self, context: List[str], question: str) -> str:
         """プロンプトを構築"""
@@ -153,122 +208,159 @@ class QAChatbot:
     def answer(self, question: str) -> str:
         """質問に対する回答を生成"""
         print(f"質問を処理中: {question}")
-        
+
         relevant_context = self.knowledge_base.search(question, top_k=3)
         print(f"関連する情報を{len(relevant_context)}件見つけました。")
-        
-        if self.generator is None:
-            return self._simple_answer(relevant_context, question)
-
         try:
             prompt = self._build_prompt(relevant_context, question)
-            encoded = self.tokenizer(prompt, return_tensors="pt")
-            prompt_tokens = encoded.input_ids.shape[1]
-            max_tokens = 512
-            max_new_tokens = max(1, max_tokens - prompt_tokens)
 
-            response = self.generator(
-                prompt,
-                max_new_tokens=max_new_tokens,
-                num_return_sequences=1,
-                temperature=0.7
-            )
-            
-            generated_text = response[0]['generated_text']
-            answer = generated_text[len(prompt):].strip()
-            
+            if self.provider == "local" and self.generator is not None:
+                encoded = self.tokenizer(prompt, return_tensors="pt")
+                prompt_tokens = encoded.input_ids.shape[1]
+                max_tokens = 512
+                max_new_tokens = max(1, max_tokens - prompt_tokens)
+
+                response = self.generator(
+                    prompt,
+                    max_new_tokens=max_new_tokens,
+                    num_return_sequences=1,
+                    temperature=0.7
+                )
+                generated_text = response[0]['generated_text']
+                answer = generated_text[len(prompt):].strip()
+
+            elif self.provider == "azure" and self.client is not None:
+                response = self.client.chat.completions.create(
+                    model=self.deployment_name,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=500,
+                    temperature=0.3,
+                    top_p=0.9
+                )
+                answer = response.choices[0].message.content.strip()
+
+            elif self.provider == "aws" and self.client is not None:
+                payload = {
+                    "inputText": prompt,
+                    "textGenerationConfig": {
+                        "maxTokenCount": 512,
+                        "temperature": 0.3
+                    }
+                }
+                aws_response = self.client.invoke_model(
+                    modelId=self.model_id,
+                    body=json.dumps(payload)
+                )
+                body = json.loads(aws_response["body"].read())
+                answer = body.get("results", [{}])[0].get("outputText", "").strip()
+            else:
+                answer = None
+
             if not answer or len(answer) < 10:
                 return self._simple_answer(relevant_context, question)
-            
+
             return answer
-            
+
         except Exception as e:
             print(f"回答生成中にエラーが発生しました: {e}")
             return self._simple_answer(relevant_context, question)
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="RAG型社内QAチャットボット")
+    parser.add_argument("--provider", choices=["local", "azure", "aws"], default="local")
+    parser.add_argument("--deployment_name", default="gpt-35-turbo")
+    parser.add_argument("--model_id", default="amazon.titan-text-lite-v1")
+    args = parser.parse_args()
+
     print("RAG型社内QAチャットボットを起動中...")
-    
+
     dummy_documents = [
         """
         経費精算ルール
-        
+
         1. 経費精算の上限について
         交通費: 月額50,000円まで
         接待費: 1回あたり10,000円まで、月額30,000円まで
         書籍・研修費: 年額100,000円まで
-        
+
         2. 申請方法
         経費精算システムにログインし、レシートの写真を添付して申請してください。
         申請期限は費用発生から1ヶ月以内です。
-        
+
         3. 承認フロー
         5,000円未満: 直属上司の承認のみ
         5,000円以上: 直属上司 + 部長の承認が必要
         """,
-        
+
         """
         有給休暇申請ガイド
-        
+
         1. 有給休暇の取得について
         入社から6ヶ月経過後に10日間付与されます。
         以降、1年ごとに付与日数が増加します。
         有給休暇の有効期限は2年間です。
-        
+
         2. 申請方法
         有給休暇申請システムから申請してください。
         緊急時を除き、取得希望日の3営業日前までに申請が必要です。
-        
+
         3. 連続取得について
         5日以上の連続取得の場合は、2週間前までに申請してください。
         業務の引き継ぎ資料の作成も忘れずに行ってください。
         """,
-        
+
         """
         社内システム利用ガイド
-        
+
         1. ログイン情報
         社員番号とパスワードでログインしてください。
         パスワードは90日ごとに変更が必要です。
-        
+
         2. 利用可能システム
         - 勤怠管理システム
         - 経費精算システム
         - 有給休暇申請システム
         - 社内掲示板
-        
+
         3. トラブル時の対応
         システムに問題が発生した場合は、IT部門（内線：1234）までご連絡ください。
         """
     ]
-    
+
     try:
         kb_manager = KnowledgeBaseManager()
         kb_manager.build_index(dummy_documents)
-        
-        chatbot = QAChatbot(kb_manager)
-        
+
+        if args.provider == "azure":
+            chatbot = QAChatbot(kb_manager, provider="azure", deployment_name=args.deployment_name)
+        elif args.provider == "aws":
+            chatbot = QAChatbot(kb_manager, provider="aws", model_id=args.model_id)
+        else:
+            chatbot = QAChatbot(kb_manager)
+
         test_questions = [
             "経費精算の上限はいくらですか？",
             "有給休暇はいつから取得できますか？",
             "システムにログインできない場合はどうすればいいですか？",
             "会社の創立年はいつですか？"
         ]
-        
+
         print("\n" + "="*50)
         print("QAチャットボットのデモンストレーション")
         print("="*50)
-        
+
         for question in test_questions:
             print(f"\n質問: {question}")
             print("-" * 30)
             answer = chatbot.answer(question)
             print(f"回答: {answer}")
             print()
-            
+
     except Exception as e:
         print(f"エラーが発生しました: {e}")
         print("必要なライブラリがインストールされていない可能性があります。")
         print("以下のコマンドでインストールしてください：")
-        print("pip install torch transformers sentence-transformers faiss-cpu numpy")
+        print("pip install torch transformers sentence-transformers faiss-cpu numpy boto3 openai")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ transformers>=4.20.0
 sentence-transformers>=2.2.0
 faiss-cpu>=1.7.0
 numpy>=1.21.0
+boto3>=1.28.0
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- Translate README into English and link from original README
- Extend documentation for running on AWS Bedrock, Azure OpenAI or locally
- Generalize chatbot to select LLM provider (local/Azure/AWS) with new CLI options
- Add boto3 and OpenAI dependencies

## Testing
- `pytest -q`
- `python quick_test.py`

------
https://chatgpt.com/codex/tasks/task_e_688dc3619dec832a80b88607b6ba54d0