### PR TITLE
Add Terraform infrastructure for Azure deployment

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,20 @@
+# Infrastructure as Code
+
+This directory contains Terraform configuration for deploying the Azure resources
+used by the QA bot. The structure separates reusable modules from environment
+specific configurations.
+
+```
+terraform/
+  modules/
+    base/         # Module provisioning API Management, Container Apps, etc.
+  dev/            # Development environment using the base module
+```
+
+To deploy the dev environment:
+
+```sh
+cd terraform/dev
+terraform init
+terraform apply
+```

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+module "base" {
+  source          = "../modules/base"
+  prefix          = var.prefix
+  location        = var.location
+  container_image = var.container_image
+}
+
+output "resource_group" {
+  value = module.base.resource_group_name
+}
+
+output "app_url" {
+  value = module.base.container_app_url
+}

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -1,0 +1,17 @@
+variable "prefix" {
+  description = "Prefix used for all resource names"
+  type        = string
+  default     = "qa-bot"
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+  default     = "japaneast"
+}
+
+variable "container_image" {
+  description = "Container image reference"
+  type        = string
+  default     = "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
+}

--- a/terraform/modules/base/main.tf
+++ b/terraform/modules/base/main.tf
@@ -1,0 +1,141 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.70"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${var.prefix}-rg"
+  location = var.location
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${var.prefix}-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "${var.prefix}-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.1.0/24"]
+  delegations {
+    name = "delegation"
+    service_delegation {
+      name = "Microsoft.Web/containerApps"
+    }
+  }
+}
+
+resource "azurerm_log_analytics_workspace" "law" {
+  name                = "${var.prefix}-law"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_container_app_environment" "env" {
+  name                       = "${var.prefix}-cae"
+  location                   = var.location
+  resource_group_name        = azurerm_resource_group.rg.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.law.id
+}
+
+resource "azurerm_application_insights" "appinsights" {
+  name                = "${var.prefix}-appi"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+  application_type    = "web"
+}
+
+resource "azurerm_container_app" "app" {
+  name                         = "${var.prefix}-app"
+  resource_group_name          = azurerm_resource_group.rg.name
+  location                     = var.location
+  container_app_environment_id = azurerm_container_app_environment.env.id
+  revision_mode                = "Single"
+  template {
+    container {
+      name   = "app"
+      image  = var.container_image
+      cpu    = 0.5
+      memory = "1Gi"
+      env {
+        name  = "APPINSIGHTS_INSTRUMENTATIONKEY"
+        value = azurerm_application_insights.appinsights.instrumentation_key
+      }
+    }
+    scale {
+      min_replicas = 1
+      max_replicas = 5
+    }
+  }
+  ingress {
+    external_enabled = true
+    target_port      = 80
+    traffic_weight {
+      latest_revision = true
+      weight          = 100
+    }
+  }
+}
+
+resource "azurerm_key_vault" "kv" {
+  name                        = "${var.prefix}kv"
+  location                    = var.location
+  resource_group_name         = azurerm_resource_group.rg.name
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  sku_name                    = "standard"
+  purge_protection_enabled    = false
+  soft_delete_retention_days  = 7
+}
+
+resource "azurerm_key_vault_secret" "example" {
+  name         = "slack-bot-token"
+  value        = "CHANGE_ME"
+  key_vault_id = azurerm_key_vault.kv.id
+}
+
+resource "azurerm_cosmosdb_account" "cosmos" {
+  name                = "${var.prefix}-cosmos"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+  offer_type          = "Standard"
+  kind                = "MongoDB"
+  enable_free_tier    = true
+  consistency_policy {
+    consistency_level = "Session"
+  }
+  capabilities {
+    name = "EnableMongo"
+  }
+}
+
+resource "azurerm_cosmosdb_mongo_database" "db" {
+  name                = "appdb"
+  resource_group_name = azurerm_resource_group.rg.name
+  account_name        = azurerm_cosmosdb_account.cosmos.name
+}
+
+resource "azurerm_api_management" "apim" {
+  name                = "${var.prefix}-apim"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+  publisher_name      = "Example"
+  publisher_email     = "example@example.com"
+  sku_name            = "Consumption_0"
+}
+

--- a/terraform/modules/base/outputs.tf
+++ b/terraform/modules/base/outputs.tf
@@ -1,0 +1,7 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "container_app_url" {
+  value = azurerm_container_app.app.latest_revision_fqdn
+}

--- a/terraform/modules/base/variables.tf
+++ b/terraform/modules/base/variables.tf
@@ -1,0 +1,15 @@
+variable "prefix" {
+  description = "Prefix used for all resource names"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region to deploy resources"
+  type        = string
+  default     = "japaneast"
+}
+
+variable "container_image" {
+  description = "Container image for the application"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add reusable Terraform module provisioning core Azure resources
- expose a development environment referencing the module

## Testing
- `pytest`
- `terraform fmt -recursive` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688dc3f97fd4832aaf39b96c99305f69